### PR TITLE
Suppress a warning

### DIFF
--- a/lib/ruboty/handlers/feedback/url.rb
+++ b/lib/ruboty/handlers/feedback/url.rb
@@ -8,7 +8,7 @@ module Ruboty
       class URL < Ruboty::Handlers::Base
         include Ruboty::Handlers::GithubEnv
 
-        on(%r!(?<url>#{URI.regexp}) +(?<type>report|patch|help|find|info) +(?<upstream>\S+)(?: +(?<finder>\w+))?!,
+        on(%r!(?<url>#{URI::ABS_URI_REF}) +(?<type>report|patch|help|find|info) +(?<upstream>\S+)(?: +(?<finder>\w+))?!,
            name: :register,
            description: "Register URL as a feedback")
 


### PR DESCRIPTION
    lib/ruboty/handlers/feedback/url.rb:11: warning: URI.regexp is obsolete

URI.regexp has been obsoleted since Ruby 2.2.